### PR TITLE
Security fix

### DIFF
--- a/config/access.php
+++ b/config/access.php
@@ -102,7 +102,6 @@ return array(
 		),
 		'logdata'   => array(
 			'index'   => AccountLevel::ADMIN,
-			'txnview' => AccountLevel::ADMIN,
 			'char'    => AccountLevel::ADMIN,
 			'inter'   => AccountLevel::ADMIN,
 			'command' => AccountLevel::ADMIN,
@@ -122,7 +121,8 @@ return array(
 			'changepass' => AccountLevel::ADMIN,
 			'changemail' => AccountLevel::ADMIN,
 			'ban'        => AccountLevel::ADMIN,
-			'ipban'      => AccountLevel::ADMIN
+			'ipban'      => AccountLevel::ADMIN,
+			'txnview' => AccountLevel::ADMIN,			
 		),
 		'ipban'     => array(
 			'index'    => AccountLevel::ADMIN,


### PR DESCRIPTION
Was being able to see the 'txnview' log paypal to any account without being an administrator, because txnview this in the wrong array.
