### PR TITLE
[super very critical] RCE and Unlimited Credits PayPal vulnerability.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -101,6 +101,7 @@ return array(
 		//'admin2@localhost',                             // -- This array may be empty if you only use one e-mail
 		//'admin3@localhost'                              // -- because your Business Email is also checked.
 	),
+	'PaypalHackNotify'     => true,                     // Send email notification if hack attempt detected (Notification will be send for each address in list PayPalBusinessEmail and PayPalReceiverEmails)
 	'GStorageLeaderOnly'   => false,                    // Only allow guild leader to view guild storage rather than all members?
 	'DivorceKeepChild'     => false,                    // Keep child after divorce?
 	'DivorceKeepRings'     => false,                    // Keep wedding rings after divorce?

--- a/lib/Flux/PaymentNotifyRequest.php
+++ b/lib/Flux/PaymentNotifyRequest.php
@@ -112,10 +112,14 @@ class Flux_PaymentNotifyRequest {
     protected function fetch_ip()
     {
         $alt_ip = $_SERVER['REMOTE_ADDR'];
-        if (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
-            $alt_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+        if (isset($_SERVER['HTTP_X_REAL_IP'])) {
+            $alt_ip = $_SERVER['HTTP_X_REAL_IP'];
+        } elseif (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            $alt_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
         } elseif (isset($_SERVER['HTTP_CLIENT_IP'])) {
             $alt_ip = $_SERVER['HTTP_CLIENT_IP'];
+        } elseif (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
+            $alt_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
         }
 
         return $alt_ip;
@@ -128,10 +132,10 @@ class Flux_PaymentNotifyRequest {
 	 */
 	public function process()
 	{
-		$recieved_from = gethostbyaddr($this->fetch_ip());
-		$this->logPayPal('Received notification from %s (%s)', $this->fetch_ip(), $recieved_from);
+		$received_from = gethostbyaddr($this->fetch_ip());
+		$this->logPayPal('Received notification from %s (%s)', $this->fetch_ip(), $received_from);
 
-		if ($recieved_from == "notify.paypal.com" && $this->verify()) {
+		if ($received_from == "notify.paypal.com" && $this->verify()) {
 			$this->logPayPal('Proceeding to validate the authenticity of the transaction...');
 
 			$accountEmails = Flux::config('PayPalReceiverEmails');
@@ -317,7 +321,7 @@ class Flux_PaymentNotifyRequest {
 		else {
 			$this->logPayPal('Transaction invalid, aborting.');
 			
-			if($recieved_from != "notify.paypal.com" && Flux::config('PaypalHackNotify')){
+			if($received_from != "notify.paypal.com" && Flux::config('PaypalHackNotify')){
 				require_once 'Flux/Mailer.php';
 				
 				$customArray  = @unserialize(base64_decode((string)$this->ipnVariables->get('custom')));
@@ -334,7 +338,7 @@ class Flux_PaymentNotifyRequest {
 				
 				$tmpl .= "<br><br><br>";
 				$tmpl .= "<p>======= IP Info ========</p>";
-				$tmpl .= nl2br(var_export(['ip' => $this->fetch_ip(), 'host' => $recieved_from], true));
+				$tmpl .= nl2br(var_export(['ip' => $this->fetch_ip(), 'host' => $received_from], true));
 				$tmpl .= "<p>======= End IP Info ========</p>";
 				$tmpl .= "<br><br><br>";
 				$tmpl .= "<p>======= Account Info ========</p>";


### PR DESCRIPTION
Checks if payment notify recieved from paypal servers.
Prevent two critical bugs.
Special request to paypal notify with bypass of paypal reciever email
check.
1. Creates executable .php file in payments log folder via
saveDetailsToFile() function.
2. Sending fake completed payment to get unlimited credits.

Hack report example:

https://gist.github.com/S-anasol/9c91d92686bd0e882ee672a394fa1567#file-gistfile1-txt-L45-L48
Highlighted lines is bug execution example.
Bypass paypal email check(receiver_email) and create shell file(txt_id)
with any code inserted into any request variable.