### PR TITLE
Change default value for reg_date in table cp_createlog

### DIFF
--- a/data/schemas/logindb/cp_createlog.20080928225124.sql
+++ b/data/schemas/logindb/cp_createlog.20080928225124.sql
@@ -5,7 +5,7 @@ CREATE TABLE `cp_createlog` (
   `user_pass` varchar(32) NOT NULL,
   `sex` enum('M','F','S') NOT NULL default 'M',
   `email` varchar(39) NOT NULL,
-  `reg_date` datetime NOT NULL default '0000-00-00 00:00:00',
+  `reg_date` datetime NOT NULL,
   `reg_ip` varchar(100) NOT NULL,
   `delete_date` datetime default NULL,
   PRIMARY KEY  (`id`),


### PR DESCRIPTION
File: `data/schemas/logindb/cp_createlog.20080928225124.sql`

#### Error: 
Testi with MySQL 5.7 and PHP 7.1
```
Exception Flux_Error: Critical MySQL error in Installer/Updater: Invalid default value for 'reg_date'
```

#### Reason:
For currently `reg_date` defined by:
```
`reg_date` datetime NOT NULL default '0000-00-00 00:00:00',
```
But as I remember from MySQL 5.6 `default '0000-00-00 00:00:00'` not support anymore.

#### Solution:
Remove default value field `reg_date`. Default with `0000-00-00 00:00:00'` don't make any benefit for this table.